### PR TITLE
refactor(llm+ripgrep): clean up OpenLLM env vars and fix ripgrep ≥1.18 path resolution

### DIFF
--- a/apps/electron/src/renderer/components/app-menu/DesktopAppMenu.tsx
+++ b/apps/electron/src/renderer/components/app-menu/DesktopAppMenu.tsx
@@ -168,7 +168,7 @@ export function DesktopAppMenu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <TopBarButton aria-label={t("menu.craftMenu")}>
-          <CraftAgentsSymbol className="h-4 text-accent" />
+          <CraftAgentsSymbol className="h-6 text-accent" />
         </TopBarButton>
       </DropdownMenuTrigger>
       <StyledDropdownMenuContent align="start" minWidth="min-w-48">

--- a/packages/shared/src/agent/backend/internal/runtime-resolver.ts
+++ b/packages/shared/src/agent/backend/internal/runtime-resolver.ts
@@ -186,21 +186,36 @@ function resolveServerPath(hostRuntime: BackendHostRuntimeContext, serverName: s
  * shipping `vendor/ripgrep/<platform>/rg` (the binary is now compiled into
  * the native `claude` executable, but our search service in
  * `packages/server-core/src/services/search.ts` still calls it directly).
+ *
+ * `@vscode/ripgrep` ≥ 1.18 no longer places the binary inside its own
+ * `bin/` directory — it delegates to platform-specific optional-dep packages
+ * (`@vscode/ripgrep-{platform}-{arch}`). We therefore probe both the legacy
+ * path and the new platform-scoped path.
  */
 function resolveRipgrepPath(hostRuntime: BackendHostRuntimeContext): string | undefined {
   const binaryName = process.platform === 'win32' ? 'rg.exe' : 'rg';
-  const ripgrepRelative = join('node_modules', '@vscode', 'ripgrep', 'bin', binaryName);
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  // Legacy path (≤1.17): @vscode/ripgrep/bin/rg[.exe]
+  const legacyRelative = join('node_modules', '@vscode', 'ripgrep', 'bin', binaryName);
+  // New path (≥1.18): @vscode/ripgrep-{platform}-{arch}/bin/rg[.exe]
+  const platformRelative = join('node_modules', '@vscode', `ripgrep-${process.platform}-${arch}`, 'bin', binaryName);
+
+  const candidates = [legacyRelative, platformRelative];
 
   if (hostRuntime.isPackaged) {
-    const packaged = join(hostRuntime.appRootPath, ripgrepRelative);
-    if (existsSync(packaged)) return packaged;
+    for (const rel of candidates) {
+      const packaged = join(hostRuntime.appRootPath, rel);
+      if (existsSync(packaged)) return packaged;
+    }
   }
 
-  const fromHostRoot = resolveUpwards(hostRuntime.appRootPath, ripgrepRelative, 10);
-  if (fromHostRoot) return fromHostRoot;
+  for (const rel of candidates) {
+    const fromHostRoot = resolveUpwards(hostRuntime.appRootPath, rel, 10);
+    if (fromHostRoot) return fromHostRoot;
 
-  const cwdFallback = join(process.cwd(), ripgrepRelative);
-  if (existsSync(cwdFallback)) return cwdFallback;
+    const cwdFallback = join(process.cwd(), rel);
+    if (existsSync(cwdFallback)) return cwdFallback;
+  }
 
   // Non-packaged (headless server, dev mode): fall back to system rg via PATH.
   // Packaged apps must use vendored binary only — never resolve from PATH

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -55,23 +55,12 @@ export type LlmProviderType =
   | 'pi_compat'
   | 'openllm';
 
-/** Environment variable set by the user to provide the host for user-configured OpenLLM Connections. */
-export const OPENLLM_HOST_ENV_VAR = 'OPENLLM_HOST';
-
-/** Deployment-owned env var that triggers the built-in OpenLLM Environment Connection. */
-export const OPENLLM_BASE_HOST_ENV_VAR = 'OPENLLM_BASE_HOST';
-
 /** Pi auth-provider hint used for OpenAI Chat Completions-compatible OpenLLM endpoints. */
 export const OPENLLM_PI_AUTH_PROVIDER = 'openai';
 
 /** Reserved slug for the synthesized OpenLLM environment connection. */
 export const OPENLLM_ENV_CONNECTION_SLUG = 'openllm-env';
 
-/** Comma-separated model list env var for the built-in OpenLLM Environment Connection. First entry is the default model. */
-export const OPENLLM_BASE_MODELS_ENV_VAR = 'OPENLLM_BASE_MODELS';
-
-/** Optional display name override for the built-in OpenLLM Environment Connection. */
-export const OPENLLM_BASE_CONNECTION_NAME_ENV_VAR = 'OPENLLM_BASE_CONNECTION_NAME';
 
 /**
  * Build the per-model OpenLLM endpoint URL.
@@ -79,8 +68,8 @@ export const OPENLLM_BASE_CONNECTION_NAME_ENV_VAR = 'OPENLLM_BASE_CONNECTION_NAM
  *                    false for user-configured connections (reads OPENLLM_HOST).
  */
 export function buildOpenLlmBaseUrl(modelName: string, env: NodeJS.ProcessEnv = process.env, isBuiltIn = false): string {
-  const envVar = isBuiltIn ? OPENLLM_BASE_HOST_ENV_VAR : OPENLLM_HOST_ENV_VAR;
-  const host = env[envVar]?.trim();
+  const envVar = isBuiltIn ? process.env.OPENLLM_BASE_HOST : process.env.OPENLLM_HOST;
+  const host = envVar?.trim();
   if (!host) {
     throw new Error(`${envVar} is required for OpenLLM connections`);
   }


### PR DESCRIPTION
## Summary

- **Remove unused env var constants** (`OPENLLM_HOST_ENV_VAR`, `OPENLLM_BASE_HOST_ENV_VAR`, `OPENLLM_BASE_MODELS_ENV_VAR`, `OPENLLM_BASE_CONNECTION_NAME_ENV_VAR`) from `llm-connections.ts` and simplify `buildOpenLlmBaseUrl` to read `process.env.OPENLLM_BASE_HOST` / `process.env.OPENLLM_HOST` with static dot-notation — making esbuild's `--define` substitution actually take effect at build time.
- **Support ripgrep ≥1.18 path layout** in `runtime-resolver.ts`: probe both the legacy `@vscode/ripgrep/bin/rg` path (≤1.17) and the new platform-scoped `@vscode/ripgrep-{platform}-{arch}/bin/rg` path (≥1.18) so the binary resolves correctly across package versions.
- **Increase logo icon size** in `DesktopAppMenu` from `h-4` to `h-6`.

## Test plan

- [ ] Verify `OPENLLM_BASE_HOST` is baked into the Electron main bundle (`grep OPENLLM apps/electron/dist/main.cjs` should show the literal value, not a `process.env` read)
- [ ] Confirm ripgrep resolves on a system with `@vscode/ripgrep` ≥1.18 installed
- [ ] Smoke-test the desktop app menu logo renders at the correct size

🤖 Generated with [Claude Code](https://claude.com/claude-code)